### PR TITLE
Adding script and documentation to build firmware locally using docker/podman

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+zmk
+build/

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,8 @@ TOTEM is a 38 key column-staggered split keyboard running [ZMK](https://zmk.dev/
 
 ## HOW TO USE
 
+### GitHub Actions
+
 - fork this repo
 - `git clone` your repo, to create a local copy on your PC (you can use the [command line](https://www.atlassian.com/git/tutorials) or [github desktop](https://desktop.github.com/))
 - adjust the totem.keymap file (find all the keycodes on [the zmk docs pages](https://zmk.dev/docs/codes/))
@@ -28,3 +30,29 @@ TOTEM is a 38 key column-staggered split keyboard running [ZMK](https://zmk.dev/
 - the keyboard should now appear as a mass storage device
 - drag'n'drop the `totem_left-seeeduino_xiao_ble-zmk.uf2` file from the archive onto the storage device
 - repeat this process with the right half and the `totem_right-seeeduino_xiao_ble-zmk.uf2` file.
+
+### Build locally with `west.sh`
+
+You can use the `west.sh` script to build the firmware locally. 
+
+Running it initializes a ZMK environment in a container, which requires either `podman` or `docker` to be installed for it to work. `git` should also be installed, as cloning the ZMK git repo is required to configure a working ZMK environment.
+
+```bash
+# First, run the west.sh script
+bash west.sh
+
+# After finishing initializing, you get access to the command line of a new container
+# Run the following commands to initialize the project and download dependencies :
+west init -l app/ && west update && west zephyr-export
+
+# Finally, to build the firmware for both halves of the keyboard, you can run the following commands :
+
+# left part :
+west build -s app -d /workspaces/build/left  -p -b 'seeeduino_xiao_ble' -- -DZMK_CONFIG=/workspaces/zmk-config/config -DSHIELD=totem_left
+
+# right part :
+west build -s app -d /workspaces/build/right -p -b 'seeeduino_xiao_ble' -- -DZMK_CONFIG=/workspaces/zmk-config/config -DSHIELD=totem_right
+
+# The files generated can each be found in 'build/left|right/zephyr/zmk.uf2'.
+```
+

--- a/west.sh
+++ b/west.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 
 config_dir=$(realpath $(dirname -- "$0";))
+container_mgmt=""
+
+# choose the container command (docker or podman), depending on what's currently installed
+if which podman &> /dev/null; then
+  container_mgmt="podman"
+else
+  if which docker &> /dev/null; then
+    container_mgmt="docker"
+  else
+    echo "❌ This script requires either podman or docker to be installed. Please install either, then retry."
+    exit 1
+  fi
+fi
+
+echo "✅ Found $container_mgmt executable, continuing..."
 
 # clone zmk (if not done already)
 if [ -d "$config_dir/zmk" ]; then
@@ -12,29 +27,29 @@ else
 fi
 
 # manage volumes
-echo -ne "⏳ Creating new podman volume...\r"
-podman volume rm --force zmk-config 2&> /dev/null
-podman volume create --driver local -o o=bind -o type=none -o device="$config_dir/" zmk-config 2&> /dev/null
-echo -ne "✅ Creating new podman volume... Done !\n"
+echo -ne "⏳ Creating new $container_mgmt volume...\r"
+$container_mgmt volume rm --force zmk-config 2&> /dev/null
+$container_mgmt volume create --driver local -o o=bind -o type=none -o device="$config_dir/" zmk-config 2&> /dev/null
+echo -ne "✅ Creating new $container_mgmt volume... Done !\n"
 
 # build container
-echo -ne "⏳ Building podman image...\r"
-podman build -t zmk-west -f "$config_dir/zmk/.devcontainer/Dockerfile" 2&> /dev/null
-echo -ne "✅ Building podman image... Done !\n"
+echo -ne "⏳ Building $container_mgmt image...\r"
+$container_mgmt build -t zmk-west -f "$config_dir/zmk/.devcontainer/Dockerfile" 2&> /dev/null
+echo -ne "✅ Building $container_mgmt image... Done !\n"
 
 echo "ℹ️  Run the following commands if running this script for the first time :"
-echo "west init -l app/ && west update && west zephyr-export"
-echo ""
-echo "ℹ️  To build the firmware for both halves of the keyboard :"
-echo "west build -s app -d /workspaces/build/left  -p -b 'seeeduino_xiao_ble' -- -DZMK_CONFIG=/workspaces/zmk-config/config -DSHIELD=totem_left"
-echo "west build -s app -d /workspaces/build/right -p -b 'seeeduino_xiao_ble' -- -DZMK_CONFIG=/workspaces/zmk-config/config -DSHIELD=totem_right"
-echo ""
-echo "ℹ️  The files generated can be found in 'build/left|right/zephyr/zmk.uf2'."
+echo -e "west init -l app/ && west update && west zephyr-export\n"
+
+echo -e "ℹ️ To build the firmware for both halves of the keyboard :\n"
+echo -e "west build -s app -d /workspaces/build/left -p -b 'seeeduino_xiao_ble' -- -DZMK_CONFIG=/workspaces/zmk-config/config -DSHIELD=totem_left\n"
+echo -e "west build -s app -d /workspaces/build/right -p -b 'seeeduino_xiao_ble' -- -DZMK_CONFIG=/workspaces/zmk-config/config -DSHIELD=totem_right\n"
+
+echo "ℹ️ The files generated can be found in 'build/left|right/zephyr/zmk.uf2'."
 
 mkdir -p "$config_dir/build"
 
 # run the container
-podman run -it --rm \
+$container_mgmt run -it --rm \
   --security-opt label=disable \
   --workdir /workspaces/zmk \
   -v "$config_dir/zmk:/workspaces/zmk" \

--- a/west.sh
+++ b/west.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+config_dir=$(realpath $(dirname -- "$0";))
+
+# clone zmk (if not done already)
+if [ -d "$config_dir/zmk" ]; then
+  echo "✅ ZMK Directory already exists"
+else
+  echo -ne "⏳ Cloning ZMK git repo...\r"
+  git clone https://github.com/zmkfirmware/zmk.git "$config_dir/zmk"
+  echo -ne "✅ Cloning ZMK git repo... Done !\n"
+fi
+
+# manage volumes
+echo -ne "⏳ Creating new podman volume...\r"
+podman volume rm --force zmk-config 2&> /dev/null
+podman volume create --driver local -o o=bind -o type=none -o device="$config_dir/" zmk-config 2&> /dev/null
+echo -ne "✅ Creating new podman volume... Done !\n"
+
+# build container
+echo -ne "⏳ Building podman image...\r"
+podman build -t zmk-west -f "$config_dir/zmk/.devcontainer/Dockerfile" 2&> /dev/null
+echo -ne "✅ Building podman image... Done !\n"
+
+echo "ℹ️  Run the following commands if running this script for the first time :"
+echo "west init -l app/ && west update && west zephyr-export"
+echo ""
+echo "ℹ️  To build the firmware for both halves of the keyboard :"
+echo "west build -s app -d /workspaces/build/left  -p -b 'seeeduino_xiao_ble' -- -DZMK_CONFIG=/workspaces/zmk-config/config -DSHIELD=totem_left"
+echo "west build -s app -d /workspaces/build/right -p -b 'seeeduino_xiao_ble' -- -DZMK_CONFIG=/workspaces/zmk-config/config -DSHIELD=totem_right"
+echo ""
+echo "ℹ️  The files generated can be found in 'build/left|right/zephyr/zmk.uf2'."
+
+mkdir -p "$config_dir/build"
+
+# run the container
+podman run -it --rm \
+  --security-opt label=disable \
+  --workdir /workspaces/zmk \
+  -v "$config_dir/zmk:/workspaces/zmk" \
+  -v "$config_dir:/workspaces/zmk-config" \
+  -v "$config_dir/build:/workspaces/build" \
+  -p 3000:3000 \
+  zmk-west /bin/bash


### PR DESCRIPTION
Hello ! I've written a small script that uses either docker or podman to put in place a ZMK environment, based on the official [ZMK documentation](https://zmk.dev/docs/development/local-toolchain/setup/container?container=podman).

The script also shows some helpful commands to the user : how to initialize the project, which commands to run to build each halves, and where the resulting firmware can be found :

![image](https://github.com/user-attachments/assets/b2f733e8-e25c-4a93-bf2c-987fe9d4e20a)

The README was also updated with this information.