### PR TITLE
Migrate from XIAO nRF52840 to XIAO RP2040 with wired UART split

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,5 @@
 include:
-  - board: seeeduino_xiao_ble
+  - board: seeeduino_xiao_rp2040
     shield: totem_left
-  - board: seeeduino_xiao_ble
+  - board: seeeduino_xiao_rp2040
     shield: totem_right
-# there is no settingsreset (needed) for the XIAO

--- a/config/boards/shields/totem/totem_left.conf
+++ b/config/boards/shields/totem/totem_left.conf
@@ -1,0 +1,9 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+# Enable UART split communication
+CONFIG_ZMK_SPLIT_UART=y
+
+# Disable BLE (not available on RP2040)
+CONFIG_BT=n
+CONFIG_ZMK_BLE=n

--- a/config/boards/shields/totem/totem_left.overlay
+++ b/config/boards/shields/totem/totem_left.overlay
@@ -15,3 +15,15 @@
         , <&xiao_d 8 GPIO_ACTIVE_HIGH>
         ;
 };
+
+/ {
+    chosen {
+        zmk,split-uart = &sercom0;
+    };
+};
+
+&sercom0 {
+    status = "okay";
+    compatible = "arduino,serial";
+    current-speed = <115200>;
+};

--- a/config/boards/shields/totem/totem_right.conf
+++ b/config/boards/shields/totem/totem_right.conf
@@ -1,0 +1,9 @@
+# Copyright (c) 2022 The ZMK Contributors
+# SPDX-License-Identifier: MIT
+
+# Enable UART split communication
+CONFIG_ZMK_SPLIT_UART=y
+
+# Disable BLE (not available on RP2040)
+CONFIG_BT=n
+CONFIG_ZMK_BLE=n

--- a/config/boards/shields/totem/totem_right.overlay
+++ b/config/boards/shields/totem/totem_right.overlay
@@ -19,3 +19,15 @@
         , <&xiao_d 4 GPIO_ACTIVE_HIGH>
         ;
 };
+
+/ {
+    chosen {
+        zmk,split-uart = &sercom0;
+    };
+};
+
+&sercom0 {
+    status = "okay";
+    compatible = "arduino,serial";
+    current-speed = <115200>;
+};


### PR DESCRIPTION
- Updated build.yaml to use seeeduino_xiao_rp2040 board
- Added UART serial communication configuration to overlays
- Enabled CONFIG_ZMK_SPLIT_UART in shield configs
- Disabled BLE (not available on RP2040)
- Configured for wired TRRS cable connection