### PR TITLE
Board id change to xiao_ble

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,6 @@
 include:
-  - board: seeeduino_xiao_ble
+  - board: xiao_ble
     shield: totem_left
-  - board: seeeduino_xiao_ble
+  - board: xiao_ble
     shield: totem_right
 # there is no settingsreset (needed) for the XIAO

--- a/config/boards/shields/totem/totem.zmk.yml
+++ b/config/boards/shields/totem/totem.zmk.yml
@@ -3,7 +3,7 @@ id: totem
 name: TOTEM
 type: shield
 url: https://github.com/GEIGEIGEIST/TOTEM
-requires: [seeeduino_xiao_ble]
+requires: [xiao_ble]
 features:
   - keys
 siblings:

--- a/readme.md
+++ b/readme.md
@@ -26,5 +26,5 @@ TOTEM is a 38 key column-staggered split keyboard running [ZMK](https://zmk.dev/
 - scroll down and unzip the `firmware.zip` archive that contains the latest firmware
 - connect the left half of the TOTEM to your PC, press reset twice
 - the keyboard should now appear as a mass storage device
-- drag'n'drop the `totem_left-seeeduino_xiao_ble-zmk.uf2` file from the archive onto the storage device
-- repeat this process with the right half and the `totem_right-seeeduino_xiao_ble-zmk.uf2` file.
+- drag'n'drop the `totem_left-xiao_ble-zmk.uf2` file from the archive onto the storage device
+- repeat this process with the right half and the `totem_right-xiao_ble-zmk.uf2` file.


### PR DESCRIPTION
Original id seeeduino_xiao_ble is not supported in build after recent ZMK update. This should cover #70 reported by @peterdenham.